### PR TITLE
Use a wait function impemented in C

### DIFF
--- a/psycopg/psycopg/_enums.py
+++ b/psycopg/psycopg/_enums.py
@@ -8,8 +8,21 @@ libpq-defined enums.
 # Copyright (C) 2020 The Psycopg Team
 
 from enum import Enum, IntEnum
+from selectors import EVENT_READ, EVENT_WRITE
 
 from . import pq
+
+
+class Wait(IntEnum):
+    R = EVENT_READ
+    W = EVENT_WRITE
+    RW = EVENT_READ | EVENT_WRITE
+
+
+class Ready(IntEnum):
+    R = EVENT_READ
+    W = EVENT_WRITE
+    RW = EVENT_READ | EVENT_WRITE
 
 
 class PyFormat(str, Enum):

--- a/psycopg/psycopg/abc.py
+++ b/psycopg/psycopg/abc.py
@@ -46,6 +46,17 @@ PQGen: TypeAlias = Generator["Wait", "Ready", RV]
 """
 
 
+class WaitFunc(Protocol):
+    """
+    Wait on the connection which generated `PQgen` and return its final result.
+    """
+
+    def __call__(
+        self, gen: PQGen[RV], fileno: int, timeout: Optional[float] = None
+    ) -> RV:
+        ...
+
+
 # Adaptation types
 
 DumpFunc: TypeAlias = Callable[[Any], Buffer]

--- a/psycopg/psycopg/copy.py
+++ b/psycopg/psycopg/copy.py
@@ -148,7 +148,7 @@ class BaseCopy(Generic[ConnectionType]):
 
     # High level copy protocol generators (state change of the Copy object)
 
-    def _read_gen(self) -> PQGen[memoryview]:
+    def _read_gen(self) -> PQGen[Buffer]:
         if self._finished:
             return memoryview(b"")
 
@@ -250,7 +250,7 @@ class Copy(BaseCopy["Connection[Any]"]):
 
     # End user sync interface
 
-    def __iter__(self) -> Iterator[memoryview]:
+    def __iter__(self) -> Iterator[Buffer]:
         """Implement block-by-block iteration on :sql:`COPY TO`."""
         while True:
             data = self.read()
@@ -258,7 +258,7 @@ class Copy(BaseCopy["Connection[Any]"]):
                 break
             yield data
 
-    def read(self) -> memoryview:
+    def read(self) -> Buffer:
         """
         Read an unparsed row after a :sql:`COPY TO` operation.
 
@@ -498,14 +498,14 @@ class AsyncCopy(BaseCopy["AsyncConnection[Any]"]):
     ) -> None:
         await self.finish(exc_val)
 
-    async def __aiter__(self) -> AsyncIterator[memoryview]:
+    async def __aiter__(self) -> AsyncIterator[Buffer]:
         while True:
             data = await self.read()
             if not data:
                 break
             yield data
 
-    async def read(self) -> memoryview:
+    async def read(self) -> Buffer:
         return await self.connection.wait(self._read_gen())
 
     async def rows(self) -> AsyncIterator[Tuple[Any, ...]]:

--- a/psycopg_c/psycopg_c/_psycopg.pyi
+++ b/psycopg_c/psycopg_c/_psycopg.pyi
@@ -61,6 +61,9 @@ def fetch(pgconn: PGconn) -> abc.PQGen[Optional[PGresult]]: ...
 def pipeline_communicate(
     pgconn: PGconn, commands: Deque[abc.PipelineCommand]
 ) -> abc.PQGen[List[List[PGresult]]]: ...
+def wait_c(
+    gen: abc.PQGen[abc.RV], fileno: int, timeout: Optional[float] = None
+) -> abc.RV: ...
 
 # Copy support
 def format_row_text(

--- a/psycopg_c/psycopg_c/_psycopg.pyx
+++ b/psycopg_c/psycopg_c/_psycopg.pyx
@@ -39,6 +39,7 @@ include "_psycopg/adapt.pyx"
 include "_psycopg/copy.pyx"
 include "_psycopg/generators.pyx"
 include "_psycopg/transform.pyx"
+include "_psycopg/waiting.pyx"
 
 include "types/array.pyx"
 include "types/datetime.pyx"

--- a/psycopg_c/psycopg_c/_psycopg/generators.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/generators.pyx
@@ -11,15 +11,19 @@ from typing import List
 from psycopg import errors as e
 from psycopg.pq import abc, error_message
 from psycopg.abc import PipelineCommand, PQGen
-from psycopg.waiting import Wait, Ready
+from psycopg._enums import Wait, Ready
 from psycopg._compat import Deque
 from psycopg._encodings import conninfo_encoding
 
 cdef object WAIT_W = Wait.W
 cdef object WAIT_R = Wait.R
 cdef object WAIT_RW = Wait.RW
+cdef object PY_READY_R = Ready.R
+cdef object PY_READY_W = Ready.W
+cdef object PY_READY_RW = Ready.RW
 cdef int READY_R = Ready.R
 cdef int READY_W = Ready.W
+cdef int READY_RW = Ready.RW
 
 def connect(conninfo: str) -> PQGenConn[abc.PGconn]:
     """

--- a/psycopg_c/psycopg_c/_psycopg/waiting.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/waiting.pyx
@@ -1,0 +1,197 @@
+"""
+C implementation of waiting functions
+"""
+
+# Copyright (C) 2022 The Psycopg Team
+
+from cpython.object cimport PyObject_CallFunctionObjArgs
+
+cdef extern from *:
+    """
+#if defined(HAVE_POLL) && !defined(HAVE_BROKEN_POLL)
+
+#if defined(HAVE_POLL_H)
+#include <poll.h>
+#elif defined(HAVE_SYS_POLL_H)
+#include <sys/poll.h>
+#endif
+
+#else  /* no poll available */
+
+#ifdef MS_WINDOWS
+#include <winsock2.h>
+#else
+#include <sys/select.h>
+#endif
+
+#endif  /* HAVE_POLL */
+
+#define SELECT_EV_READ 1
+#define SELECT_EV_WRITE 2
+
+#define SEC_TO_MS 1000
+#define SEC_TO_US (1000 * 1000)
+
+/* Use select to wait for readiness on fileno.
+ *
+ * - Return SELECT_EV_* if the file is ready
+ * - Return 0 on timeout
+ * - Return -1 (and set an exception) on error.
+ *
+ * The wisdom of this function comes from:
+ *
+ * - PostgreSQL libpq (see src/interfaces/libpq/fe-misc.c)
+ * - Python select module (see Modules/selectmodule.c)
+ */
+static int
+wait_c_impl(int fileno, int wait, float timeout)
+{
+    int select_rv;
+    int rv = 0;
+
+#if defined(HAVE_POLL) && !defined(HAVE_BROKEN_POLL)
+
+    struct pollfd input_fd;
+    int timeout_ms;
+
+    input_fd.fd = fileno;
+    input_fd.events = POLLERR;
+    input_fd.revents = 0;
+
+    if (wait & SELECT_EV_READ) { input_fd.events |= POLLIN; }
+    if (wait & SELECT_EV_WRITE) { input_fd.events |= POLLOUT; }
+
+    if (timeout < 0.0) {
+        timeout_ms = -1;
+    } else {
+        timeout_ms = (int)(timeout * SEC_TO_MS);
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    errno = 0;
+    select_rv = poll(&input_fd, 1, timeout_ms);
+    Py_END_ALLOW_THREADS
+
+    if (PyErr_CheckSignals()) { goto finally; }
+
+    if (select_rv < 0) {
+        goto error;
+    }
+
+    if (input_fd.events & POLLIN) { rv |= SELECT_EV_READ; }
+    if (input_fd.events & POLLOUT) { rv |= SELECT_EV_WRITE; }
+
+#else
+
+    fd_set ifds;
+    fd_set ofds;
+    fd_set efds;
+    struct timeval tv, *tvptr;
+
+#ifndef MS_WINDOWS
+    if (fileno >= 1024) {
+        PyErr_SetString(
+            PyExc_ValueError,  /* same exception of Python's 'select.select()' */
+            "connection file descriptor out of range for 'select()'");
+        return -1;
+    }
+#endif
+
+    FD_ZERO(&ifds);
+    FD_ZERO(&ofds);
+    FD_ZERO(&efds);
+
+    if (wait & SELECT_EV_READ) { FD_SET(fileno, &ifds); }
+    if (wait & SELECT_EV_WRITE) { FD_SET(fileno, &ofds); }
+    FD_SET(fileno, &efds);
+
+    /* Compute appropriate timeout interval */
+    if (timeout < 0.0) {
+        tvptr = NULL;
+    }
+    else {
+        tv.tv_sec = (int)timeout;
+        tv.tv_usec = (int)(((long)timeout * SEC_TO_US) % SEC_TO_US);
+        tvptr = &tv;
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    errno = 0;
+    select_rv = select(fileno + 1, &ifds, &ofds, &efds, tvptr);
+    Py_END_ALLOW_THREADS
+
+    if (PyErr_CheckSignals()) { goto finally; }
+
+    if (select_rv < 0) {
+        goto error;
+    }
+
+    if (FD_ISSET(fileno, &ifds)) { rv |= SELECT_EV_READ; }
+    if (FD_ISSET(fileno, &ofds)) { rv |= SELECT_EV_WRITE; }
+
+#endif  /* HAVE_POLL */
+
+    return rv;
+
+error:
+
+#ifdef MS_WINDOWS
+    if (select_rv == SOCKET_ERROR) {
+        PyErr_SetExcFromWindowsErr(PyExc_OSError, WSAGetLastError());
+    }
+#else
+    if (select_rv < 0) {
+        PyErr_SetFromErrno(PyExc_OSError);
+    }
+#endif
+    else {
+        PyErr_SetString(PyExc_OSError, "unexpected error from select()");
+    }
+
+finally:
+
+    return -1;
+
+}
+    """
+    cdef int wait_c_impl(int fileno, int wait, float timeout) except -1
+
+
+def wait_c(gen: PQGen[RV], int fileno, timeout = None) -> RV:
+    """
+    Wait for a generator using poll or select.
+    """
+    cdef float ctimeout
+    cdef int wait, ready
+    cdef PyObject *pyready
+
+    if timeout is None:
+        ctimeout = -1.0
+    else:
+        ctimeout = float(timeout)
+        if ctimeout < 0.0:
+            ctimeout = -1.0
+
+    send = gen.send
+
+    try:
+        wait = next(gen)
+
+        while True:
+            ready = wait_c_impl(fileno, wait, ctimeout)
+            if ready == 0:
+                continue
+            elif ready == READY_R:
+                pyready = <PyObject *>PY_READY_R
+            elif ready == READY_RW:
+                pyready = <PyObject *>PY_READY_RW
+            elif ready == READY_W:
+                pyready = <PyObject *>PY_READY_W
+            else:
+                raise AssertionError(f"unexpected ready value: {ready}")
+
+            wait = PyObject_CallFunctionObjArgs(send, pyready, NULL)
+
+    except StopIteration as ex:
+        rv: RV = ex.args[0] if ex.args else None
+        return rv

--- a/psycopg_c/psycopg_c/pq.pxd
+++ b/psycopg_c/psycopg_c/pq.pxd
@@ -27,6 +27,7 @@ cdef class PGconn:
     @staticmethod
     cdef PGconn _from_ptr(libpq.PGconn *ptr)
 
+    cpdef int flush(self) except -1
     cpdef object notifies(self)
 
 

--- a/psycopg_c/psycopg_c/pq/pgconn.pyx
+++ b/psycopg_c/psycopg_c/pq/pgconn.pyx
@@ -440,7 +440,7 @@ cdef class PGconn:
         if 0 > libpq.PQsetnonblocking(self._pgconn_ptr, arg):
             raise e.OperationalError(f"setting nonblocking failed: {error_message(self)}")
 
-    def flush(self) -> int:
+    cpdef int flush(self) except -1:
         if self._pgconn_ptr == NULL:
             raise e.OperationalError(f"flushing failed: the connection is closed")
         cdef int rv = libpq.PQflush(self._pgconn_ptr)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import sys
 import asyncio
+import selectors
 from typing import List
 
 import pytest
@@ -58,11 +59,14 @@ def pytest_addoption(parser):
 
 
 def pytest_report_header(config):
-    loop = config.getoption("--loop")
-    if loop == "default":
-        return []
+    rv = []
 
-    return [f"asyncio loop: {loop}"]
+    rv.append(f"default selector: {selectors.DefaultSelector.__name__}")
+    loop = config.getoption("--loop")
+    if loop != "default":
+        rv.append(f"asyncio loop: {loop}")
+
+    return rv
 
 
 def pytest_sessionstart(session):

--- a/tests/scripts/bench-411.py
+++ b/tests/scripts/bench-411.py
@@ -1,0 +1,300 @@
+import os
+import sys
+import time
+import random
+import asyncio
+import logging
+from enum import Enum
+from typing import Any, Dict, List, Generator
+from argparse import ArgumentParser, Namespace
+from contextlib import contextmanager
+
+logger = logging.getLogger()
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+
+
+class Driver(str, Enum):
+    psycopg2 = "psycopg2"
+    psycopg = "psycopg"
+    psycopg_async = "psycopg_async"
+    asyncpg = "asyncpg"
+
+
+ids: List[int] = []
+data: List[Dict[str, Any]] = []
+
+
+def main() -> None:
+
+    args = parse_cmdline()
+
+    ids[:] = range(args.ntests)
+    data[:] = [
+        dict(
+            id=i,
+            name="c%d" % i,
+            description="c%d" % i,
+            q=i * 10,
+            p=i * 20,
+            x=i * 30,
+            y=i * 40,
+        )
+        for i in ids
+    ]
+
+    # Must be done just on end
+    drop_at_the_end = args.drop
+    args.drop = False
+
+    for i, name in enumerate(args.drivers):
+        if i == len(args.drivers) - 1:
+            args.drop = drop_at_the_end
+
+        if name == Driver.psycopg2:
+            import psycopg2  # type: ignore
+
+            run_psycopg2(psycopg2, args)
+
+        elif name == Driver.psycopg:
+            import psycopg
+
+            run_psycopg(psycopg, args)
+
+        elif name == Driver.psycopg_async:
+            import psycopg
+
+            if sys.platform == "win32":
+                if hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
+                    asyncio.set_event_loop_policy(
+                        asyncio.WindowsSelectorEventLoopPolicy()
+                    )
+
+            asyncio.run(run_psycopg_async(psycopg, args))
+
+        elif name == Driver.asyncpg:
+            import asyncpg  # type: ignore
+
+            asyncio.run(run_asyncpg(asyncpg, args))
+
+        else:
+            raise AssertionError(f"unknown driver: {name!r}")
+
+        # Must be done just on start
+        args.create = False
+
+
+table = """
+CREATE TABLE customer (
+        id SERIAL NOT NULL,
+        name VARCHAR(255),
+        description VARCHAR(255),
+        q INTEGER,
+        p INTEGER,
+        x INTEGER,
+        y INTEGER,
+        z INTEGER,
+        PRIMARY KEY (id)
+)
+"""
+drop = "DROP TABLE IF EXISTS customer"
+
+insert = """
+INSERT INTO customer (id, name, description, q, p, x, y) VALUES
+(%(id)s, %(name)s, %(description)s, %(q)s, %(p)s, %(x)s, %(y)s)
+"""
+
+select = """
+SELECT customer.id, customer.name, customer.description, customer.q,
+    customer.p, customer.x, customer.y, customer.z
+FROM customer
+WHERE customer.id = %(id)s
+"""
+
+
+@contextmanager
+def time_log(message: str) -> Generator[None, None, None]:
+    start = time.monotonic()
+    yield
+    end = time.monotonic()
+    logger.info(f"Run {message} in {end-start} s")
+
+
+def run_psycopg2(psycopg2: Any, args: Namespace) -> None:
+    logger.info("Running psycopg2")
+
+    if args.create:
+        logger.info(f"inserting {args.ntests} test records")
+        with psycopg2.connect(args.dsn) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(drop)
+                cursor.execute(table)
+                cursor.executemany(insert, data)
+            conn.commit()
+
+    logger.info(f"running {args.ntests} queries")
+    to_query = random.choices(ids, k=args.ntests)
+    with psycopg2.connect(args.dsn) as conn:
+        with time_log("psycopg2"):
+            for id_ in to_query:
+                with conn.cursor() as cursor:
+                    cursor.execute(select, {"id": id_})
+                    cursor.fetchall()
+                # conn.rollback()
+
+    if args.drop:
+        logger.info("dropping test records")
+        with psycopg2.connect(args.dsn) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(drop)
+            conn.commit()
+
+
+def run_psycopg(psycopg: Any, args: Namespace) -> None:
+    logger.info("Running psycopg sync")
+
+    if args.create:
+        logger.info(f"inserting {args.ntests} test records")
+        with psycopg.connect(args.dsn) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(drop)
+                cursor.execute(table)
+                cursor.executemany(insert, data)
+            conn.commit()
+
+    logger.info(f"running {args.ntests} queries")
+    to_query = random.choices(ids, k=args.ntests)
+    with psycopg.connect(args.dsn) as conn:
+        with time_log("psycopg"):
+            for id_ in to_query:
+                with conn.cursor() as cursor:
+                    cursor.execute(select, {"id": id_})
+                    cursor.fetchall()
+                # conn.rollback()
+
+    if args.drop:
+        logger.info("dropping test records")
+        with psycopg.connect(args.dsn) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(drop)
+            conn.commit()
+
+
+async def run_psycopg_async(psycopg: Any, args: Namespace) -> None:
+    logger.info("Running psycopg async")
+
+    conn: Any
+
+    if args.create:
+        logger.info(f"inserting {args.ntests} test records")
+        async with await psycopg.AsyncConnection.connect(args.dsn) as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(drop)
+                await cursor.execute(table)
+                await cursor.executemany(insert, data)
+            await conn.commit()
+
+    logger.info(f"running {args.ntests} queries")
+    to_query = random.choices(ids, k=args.ntests)
+    async with await psycopg.AsyncConnection.connect(args.dsn) as conn:
+        with time_log("psycopg_async"):
+            for id_ in to_query:
+                cursor = await conn.execute(select, {"id": id_})
+                await cursor.fetchall()
+                await cursor.close()
+                # await conn.rollback()
+
+    if args.drop:
+        logger.info("dropping test records")
+        async with await psycopg.AsyncConnection.connect(args.dsn) as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(drop)
+            await conn.commit()
+
+
+async def run_asyncpg(asyncpg: Any, args: Namespace) -> None:
+    logger.info("Running asyncpg")
+
+    places = dict(id="$1", name="$2", description="$3", q="$4", p="$5", x="$6", y="$7")
+    a_insert = insert % places
+    a_select = select % {"id": "$1"}
+
+    conn: Any
+
+    if args.create:
+        logger.info(f"inserting {args.ntests} test records")
+        conn = await asyncpg.connect(args.dsn)
+        async with conn.transaction():
+            await conn.execute(drop)
+            await conn.execute(table)
+            await conn.executemany(a_insert, [tuple(d.values()) for d in data])
+        await conn.close()
+
+    logger.info(f"running {args.ntests} queries")
+    to_query = random.choices(ids, k=args.ntests)
+    conn = await asyncpg.connect(args.dsn)
+    with time_log("asyncpg"):
+        for id_ in to_query:
+            tr = conn.transaction()
+            await tr.start()
+            await conn.fetch(a_select, id_)
+            # await tr.rollback()
+    await conn.close()
+
+    if args.drop:
+        logger.info("dropping test records")
+        conn = await asyncpg.connect(args.dsn)
+        async with conn.transaction():
+            await conn.execute(drop)
+        await conn.close()
+
+
+def parse_cmdline() -> Namespace:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "drivers",
+        nargs="+",
+        metavar="DRIVER",
+        type=Driver,
+        help=f"the drivers to test [choices: {', '.join(d.value for d in Driver)}]",
+    )
+
+    parser.add_argument(
+        "--ntests",
+        type=int,
+        default=10_000,
+        help="number of tests to perform [default: %(default)s]",
+    )
+
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("PSYCOPG_TEST_DSN", ""),
+        help="database connection string"
+        " [default: %(default)r (from PSYCOPG_TEST_DSN env var)]",
+    )
+
+    parser.add_argument(
+        "--no-create",
+        dest="create",
+        action="store_false",
+        default="True",
+        help="skip data creation before tests (it must exist already)",
+    )
+
+    parser.add_argument(
+        "--no-drop",
+        dest="drop",
+        action="store_false",
+        default="True",
+        help="skip data drop after tests",
+    )
+
+    opt = parser.parse_args()
+
+    return opt
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Recreated from original PR: https://github.com/psycopg/psycopg/pull/426

In a tight loop of fast queries, using the `wait_c` function reduces the Python overhead of about 10%.

The `tests/scripts/bench-411.py` is a simple test (inspired to the conversation in #411) comparing performances of psycopg and psycopg2. In a typical run on my laptop:

```
$ export PSYCOPG_TEST_DSN="dbname=psycopg3_test host=localhost sslmode=disable"

$ python tests/scripts/bench-411-tmp.py --no-create --no-drop psycopg psycopg2
2022-11-01 15:30:42,251 INFO Running psycopg sync
2022...